### PR TITLE
fix: prevent relay cycling on power-up by initializing GPIO LOW befor…

### DIFF
--- a/d1_mini_relay_controller/d1_mini_relay_controller.ino
+++ b/d1_mini_relay_controller/d1_mini_relay_controller.ino
@@ -102,8 +102,11 @@ void setup() {
   #endif
 
   // --- Configure Relay Pin ---
+  // Ensure relay is OFF before configuring pin to prevent power-on cycling
+  digitalWrite(RELAY_PIN, LOW);
   pinMode(RELAY_PIN, OUTPUT);
-  setRelayState(false); // Set initial state to OFF
+  digitalWrite(RELAY_PIN, LOW); // Ensure relay stays OFF after pinMode
+  relayState = false;
 
   // --- Generate MQTT Topics ---
   snprintf(discoveryTopic, sizeof(discoveryTopic), "homeassistant/cover/%s/config", DEVICE_UNIQUE_ID);


### PR DESCRIPTION
…e pinMode

- Set GPIO LOW before configuring pinMode to prevent undefined state
- Set GPIO LOW again after pinMode for reliability
- Avoid calling setRelayState() during setup which could cause momentary pulse
- Directly initialize relayState variable instead

Fixes #3